### PR TITLE
Investigate mscore CLI export capabilities

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,8 +22,9 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     && ln -s /opt/musescore/AppRun /usr/local/bin/mscore \
     && rm -rf squashfs-root /tmp/MuseScore.AppImage
 
-# Install runtime dependencies for MuseScore
+# Install runtime dependencies for MuseScore and ffmpeg
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg \
     libnss3 \
     libopengl0 \
     libjack0 \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,30 @@
 FROM mcr.microsoft.com/devcontainers/typescript-node:22
 
-# Install dependencies
-RUN apt update && \
-    apt install -y musescore && \
-    rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
+# Install MuseScore 4
+RUN curl -L -o /tmp/MuseScore.AppImage \
+      https://github.com/musescore/MuseScore/releases/download/v4.5.2/MuseScore-Studio-4.5.2.251150648-aarch64.AppImage \
+    && echo "e1ad0e205dc056be4fc23cb28bafa95bb91be58c9a215383be93d7bed4d17605  /tmp/MuseScore.AppImage" | sha256sum -c - \
+    && chmod +x /tmp/MuseScore.AppImage \
+    && /tmp/MuseScore.AppImage --appimage-extract \
+    && cp -a squashfs-root/ /opt/musescore \
+    && ln -s /opt/musescore/AppRun /usr/local/bin/mscore \
+    && rm -rf squashfs-root /tmp/MuseScore.AppImage
+
+# Install runtime dependencies for MuseScore
+RUN apt-get update && apt-get install -y \
+    libnss3 \
+    libopengl0 \
+    libjack0 \
+    libasound2 \
+    libgl1 \
+    libegl1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Setup QT for headless mode + XDG_RUNTIME_DIR
+ENV QT_QPA_PLATFORM=offscreen
+ENV XDG_RUNTIME_DIR=/tmp/xdg
+RUN mkdir -p /tmp/xdg && \
+    chown 1000:1000 /tmp/xdg && \
+    chmod 700 /tmp/xdg
 
 WORKDIR /root

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,7 +23,7 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     && rm -rf squashfs-root /tmp/MuseScore.AppImage
 
 # Install runtime dependencies for MuseScore
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libnss3 \
     libopengl0 \
     libjack0 \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,12 +1,24 @@
 FROM mcr.microsoft.com/devcontainers/typescript-node:22
 
+# Use target platform in build
+ARG TARGETARCH
+
 # Install MuseScore 4
-RUN curl -L -o /tmp/MuseScore.AppImage \
-      https://github.com/musescore/MuseScore/releases/download/v4.5.2/MuseScore-Studio-4.5.2.251150648-aarch64.AppImage \
-    && echo "e1ad0e205dc056be4fc23cb28bafa95bb91be58c9a215383be93d7bed4d17605  /tmp/MuseScore.AppImage" | sha256sum -c - \
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        MUSESCORE_URL="https://github.com/musescore/MuseScore/releases/download/v4.5.2/MuseScore-Studio-4.5.2.251141401-x86_64.AppImage"; \
+        MUSESCORE_HASH="d010b6464c78b4da23077eb4f096f949ae68bac4c809a8b008a0cfbf48e260a5"; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        MUSESCORE_URL="https://github.com/musescore/MuseScore/releases/download/v4.5.2/MuseScore-Studio-4.5.2.251150648-aarch64.AppImage"; \
+        MUSESCORE_HASH="e1ad0e205dc056be4fc23cb28bafa95bb91be58c9a215383be93d7bed4d17605"; \
+    else \
+        echo "Unsupported architecture: $TARGETARCH"; exit 1; \
+    fi; \
+    echo "Downloading $MUSESCORE_URL, expecting SHA-256 hash $MUSESCORE_HASH" \
+    && curl -L -o /tmp/MuseScore.AppImage "$MUSESCORE_URL" \
+    && echo "$MUSESCORE_HASH  /tmp/MuseScore.AppImage" | sha256sum -c - \
     && chmod +x /tmp/MuseScore.AppImage \
     && /tmp/MuseScore.AppImage --appimage-extract \
-    && cp -a squashfs-root/ /opt/musescore \
+    && rsync -a squashfs-root/ /opt/musescore \
     && ln -s /opt/musescore/AppRun /usr/local/bin/mscore \
     && rm -rf squashfs-root /tmp/MuseScore.AppImage
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,6 @@ trim_trailing_whitespace = true
 
 [.md]
 max_line_length = 80
+
+[Dockerfile]
+indent_size = 4


### PR DESCRIPTION
https://www.notion.so/Investigate-mscore-CLI-export-capabilities-25139e4b85f48026a5d8c15feea35dd0?v=24e39e4b85f4800ca327000c9a187d53&source=copy_link

Expect mscore and ffmpeg to be installed:
- `mscore --version`
- `ffmpeg -version`

Can test by adding a temporary mscz file and running the following scripts:
- `mscore --help`: should display basic help message
- `mscore -o score.pdf "My Score.mscz"`: should create score.pdf that looks like the input mscz
- `mscore -o score.mp3 "My Score.mscz"`: should create score.mp3 that looks like the input mscz

More investigation to be done later, but presumably, it appears to be working. Additional part generation can be done with `mscore --score-parts` or something similar. Will need to check the handbook.